### PR TITLE
UUID Zero can sometimes be string zero

### DIFF
--- a/pkg/journals/api_test.go
+++ b/pkg/journals/api_test.go
@@ -337,12 +337,13 @@ func TestPostAPI(t *testing.T) {
 			server = httptest.NewServer(api)
 		)
 
-		fn := func(name, authorID string, tags Tags, conBytes []byte) bool {
+		fn := func(resourceID uuid.UUID, name, authorID string, tags Tags, conBytes []byte) bool {
 			if len(name) == 0 || len(authorID) == 0 || len(conBytes) == 0 {
 				return true
 			}
 
 			doc, err := models.BuildLedger(
+				models.WithResourceID(resourceID),
 				models.WithName(name),
 				models.WithAuthorID(authorID),
 				models.WithTags(tags),
@@ -391,7 +392,7 @@ func TestPostAPI(t *testing.T) {
 			MustWriteField(writer, contentFormFile, "application/octet-stream", conBytes)
 			MustWriteField(writer, documentFormFile, "application/json", docBytes)
 
-			if err := writer.Close(); err != nil {
+			if err = writer.Close(); err != nil {
 				t.Fatal(err)
 			}
 
@@ -493,7 +494,7 @@ func TestPostAPI(t *testing.T) {
 			MustWriteField(writer, contentFormFile, "application/octet-stream", conBytes)
 			MustWriteField(writer, documentFormFile, "application/json", docBytes)
 
-			if err := writer.Close(); err != nil {
+			if err = writer.Close(); err != nil {
 				t.Fatal(err)
 			}
 
@@ -914,6 +915,7 @@ func TestPutAPI(t *testing.T) {
 			}
 
 			doc, err := models.BuildLedger(
+				models.WithResourceID(resourceID),
 				models.WithName(name),
 				models.WithAuthorID(authorID),
 				models.WithTags(tags),

--- a/pkg/ledgers/api.go
+++ b/pkg/ledgers/api.go
@@ -189,7 +189,7 @@ func (a *API) handlePut(w http.ResponseWriter, r *http.Request) {
 
 	// Make sure we collect the document for the result.
 	qr := AppendQueryResult{Errors: a.errors, Params: qp}
-	qr.ResourceID = resource.ID()
+	qr.ResourceID = resource.ResourceID()
 
 	// Finish
 	qr.Duration = time.Since(begin).String()

--- a/pkg/ledgers/api_test.go
+++ b/pkg/ledgers/api_test.go
@@ -507,12 +507,13 @@ func TestPostAPI(t *testing.T) {
 			server = httptest.NewServer(api)
 		)
 
-		fn := func(name, authorID string, tags Tags) bool {
+		fn := func(resourceID uuid.UUID, name, authorID string, tags Tags) bool {
 			if len(name) == 0 || len(authorID) == 0 {
 				return true
 			}
 
 			doc, err := models.BuildLedger(
+				models.WithResourceID(resourceID),
 				models.WithName(name),
 				models.WithAuthorID(authorID),
 				models.WithTags(tags),
@@ -875,6 +876,7 @@ func TestPutAPI(t *testing.T) {
 			}
 
 			doc, err := models.BuildLedger(
+				models.WithResourceID(resourceID),
 				models.WithName(name),
 				models.WithAuthorID(authorID),
 				models.WithTags(tags),

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -14,8 +14,19 @@ var (
 	// Empty UUID is a UUID that is considered empty.
 	Empty = UUID([36]byte{})
 
-	emptyUUID = "00000000-0000-0000-0000-000000000000"
-	layout    = regexp.MustCompile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+	emptyUUID      = "00000000-0000-0000-0000-000000000000"
+	emptyUUIDBytes = []byte{
+		48, 48, 48, 48, 48, 48, 48, 48,
+		45,
+		48, 48, 48, 48,
+		45,
+		48, 48, 48, 48,
+		45,
+		48, 48, 48, 48,
+		45,
+		48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+	}
+	layout = regexp.MustCompile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 )
 
 // UUID represents identifiers for content, resources and users
@@ -74,7 +85,17 @@ func (u UUID) Zero() bool {
 			amount++
 		}
 	}
-	return amount == 36
+	if amount == 36 {
+		return true
+	}
+
+	// Validate string
+	for k, v := range u {
+		if v != emptyUUIDBytes[k] {
+			return false
+		}
+	}
+	return true
 }
 
 func (u UUID) String() string {

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -130,4 +130,21 @@ func TestUUID(t *testing.T) {
 			t.Error(err)
 		}
 	})
+
+	t.Run("zero", func(t *testing.T) {
+		if expected, actual := true, Empty.Zero(); expected != actual {
+			t.Errorf("expected: %t, actual: %t", expected, actual)
+		}
+	})
+
+	t.Run("zero string", func(t *testing.T) {
+		id, err := Parse(Empty.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected, actual := true, id.Zero(); expected != actual {
+			t.Errorf("expected: %t, actual: %t", expected, actual)
+		}
+	})
 }


### PR DESCRIPTION
The string version of zero should be isomorphic to an empty uuid. This
fixes the issue where the uuid can be truely zero